### PR TITLE
feat(ethereum): lower min stake threshold from 0.1 to 0.01 ETH

### DIFF
--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everstake/wallet-sdk-ethereum",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Ethereum - Everstake Wallet SDK",
   "publishConfig": {
     "access": "public"

--- a/ethereum/src/__fixtures__/index.ts
+++ b/ethereum/src/__fixtures__/index.ts
@@ -221,7 +221,7 @@ export const stakeErrorFixture = [
       amount: '0.0001', // Less than minAmount
       source: '0',
     },
-    error: 'Min Amount 100000000000000000 wei',
+    error: 'Min Amount 10000000000000000 wei',
   },
 ];
 

--- a/ethereum/src/constants/index.ts
+++ b/ethereum/src/constants/index.ts
@@ -27,7 +27,7 @@ export const ETH_GAS_RESERVE = new BigNumber(220000);
 
 export const UINT16_MAX = 65535 | 0; // asm type annotation
 
-export const ETH_MIN_AMOUNT = new BigNumber('100000000000000000');
+export const ETH_MIN_AMOUNT = new BigNumber('10000000000000000');
 
 export const MULTICALL_CONTRACT_ADDRESS =
   '0xca11bde05977b3631167028862be2a173976ca11';


### PR DESCRIPTION
## Summary

Lowers the minimum ETH stake amount from 0.1 ETH to 0.01 ETH to match the updated B2C smart contract threshold. Updates the constant, test fixtures, and bumps package version.

## Changes

- Update `ETH_MIN_AMOUNT` from `100000000000000000` wei (0.1 ETH) to `10000000000000000` wei (0.01 ETH)
- Update test fixture error message to reflect new minimum
- Bump `@everstake/wallet-sdk-ethereum` version to 1.1.3

## Commits

6e21878 ⚙️ feat(ethereum): lower min stake threshold from 0.1 to 0.01 ETH