### PR TITLE
feat(solana): raise min stake threshold to 1 SOL

### DIFF
--- a/solana_v1/package.json
+++ b/solana_v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everstake/wallet-sdk-solana",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Solana - Everstake Wallet SDK",
   "publishConfig": {
     "access": "public"

--- a/solana_v1/src/constants/index.ts
+++ b/solana_v1/src/constants/index.ts
@@ -8,6 +8,7 @@ import { enums } from 'superstruct';
 
 export const SOL_CHAIN = 'solana';
 export const SOL_MIN_AMOUNT = 1000000000; // 1 SOL
+export const SOL_MIN_SPLIT_REMAINDER = 10000000; // 0.01 SOL — dust threshold for stake-account splits
 export const SOL_MAINNET_VALIDATOR_ADDRESS = new PublicKey(
   '9QU2QSxhb24FUX3Tu2FpczXjpK3VYrvRudywSZaM29mF',
 );

--- a/solana_v1/src/constants/index.ts
+++ b/solana_v1/src/constants/index.ts
@@ -7,7 +7,7 @@ import { PublicKey } from '@solana/web3.js';
 import { enums } from 'superstruct';
 
 export const SOL_CHAIN = 'solana';
-export const SOL_MIN_AMOUNT = 10000000; // 0.01 SOL
+export const SOL_MIN_AMOUNT = 1000000000; // 1 SOL
 export const SOL_MAINNET_VALIDATOR_ADDRESS = new PublicKey(
   '9QU2QSxhb24FUX3Tu2FpczXjpK3VYrvRudywSZaM29mF',
 );

--- a/solana_v1/src/solana.ts
+++ b/solana_v1/src/solana.ts
@@ -28,6 +28,7 @@ import {
   FILTER_OFFSET,
   SOL_MAINNET_VALIDATOR_ADDRESS,
   SOL_MIN_AMOUNT,
+  SOL_MIN_SPLIT_REMAINDER,
   SolNetwork,
   StakeState,
 } from './constants';
@@ -360,6 +361,9 @@ export class Solana extends Blockchain {
     source: string | null,
     lockup: Lockup | null = Lockup.default,
   ): Promise<ApiResponse<VersionedTransaction>> {
+    if (lamports < SOL_MIN_AMOUNT) {
+      this.throwError('MIN_AMOUNT_ERROR', SOL_MIN_AMOUNT.toString());
+    }
     try {
       const senderPublicKey = new PublicKey(sender);
 
@@ -552,7 +556,7 @@ export class Solana extends Blockchain {
         // If reminder amount less than min stake amount stake account automatically become disabled
         const isBelowThreshold =
           stakeAmount.lte(lamportsBN) ||
-          stakeAmount.minus(lamportsBN).lt(SOL_MIN_AMOUNT);
+          stakeAmount.minus(lamportsBN).lt(SOL_MIN_SPLIT_REMAINDER);
         if (isBelowThreshold) {
           accountsToDeactivate.push(acc);
           lamportsBN = lamportsBN.minus(stakeAmount);

--- a/solana_v2/package.json
+++ b/solana_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everstake/wallet-sdk-solana",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Solana - Everstake Wallet SDK",
   "publishConfig": {
     "access": "public"

--- a/solana_v2/src/constants/index.ts
+++ b/solana_v2/src/constants/index.ts
@@ -6,7 +6,8 @@
 import { address, Address } from '@solana/kit';
 
 export const CHAIN = 'solana';
-export const MIN_AMOUNT = 1000000000; // 1 SOL
+export const MIN_AMOUNT = 1000000000n; // 1 SOL
+export const MIN_SPLIT_REMAINDER = 10000000n; // 0.01 SOL — dust threshold for stake-account splits
 export const MAINNET_VALIDATOR_ADDRESS = address(
   '9QU2QSxhb24FUX3Tu2FpczXjpK3VYrvRudywSZaM29mF',
 );

--- a/solana_v2/src/constants/index.ts
+++ b/solana_v2/src/constants/index.ts
@@ -6,7 +6,7 @@
 import { address, Address } from '@solana/kit';
 
 export const CHAIN = 'solana';
-export const MIN_AMOUNT = 10000000; // 0.01 SOL
+export const MIN_AMOUNT = 1000000000; // 1 SOL
 export const MAINNET_VALIDATOR_ADDRESS = address(
   '9QU2QSxhb24FUX3Tu2FpczXjpK3VYrvRudywSZaM29mF',
 );

--- a/solana_v2/src/solana.ts
+++ b/solana_v2/src/solana.ts
@@ -52,6 +52,7 @@ import {
   FILTER_OFFSET,
   MAINNET_VALIDATOR_ADDRESS,
   MIN_AMOUNT,
+  MIN_SPLIT_REMAINDER,
   Network,
   StakeState,
   STAKE_ACCOUNT_V2_SIZE,
@@ -394,6 +395,9 @@ export class Solana extends Blockchain {
     // lockup: Lockup | null = Lockup.default,
     params?: Params,
   ): Promise<ApiResponse<StakeResponse>> {
+    if (lamports < MIN_AMOUNT) {
+      this.throwError('MIN_AMOUNT_ERROR', MIN_AMOUNT.toString());
+    }
     try {
       //     lockup = lockup || Lockup.default;
       // Get the minimum balance for rent exemption
@@ -648,7 +652,8 @@ export class Solana extends Blockchain {
 
         // If reminder amount less than min stake amount stake account automatically become disabled
         const isBelowThreshold =
-          stakeAmount <= lamports || stakeAmount - lamports < MIN_AMOUNT;
+          stakeAmount <= lamports ||
+          stakeAmount - lamports < MIN_SPLIT_REMAINDER;
         if (isBelowThreshold) {
           accountsToDeactivate.push(acc);
           lamports = lamports - stakeAmount;


### PR DESCRIPTION
## Summary

Raises the minimum staking threshold from 0.01 SOL to 1 SOL in both \`solana_v1\` and \`solana_v2\` packages. Fixes three correctness bugs surfaced during code review: a bigint/number type mismatch that crashed all guarded methods in v2, a silent over-unstake caused by coupling the split-dust threshold to the user-facing minimum, and a missing minimum guard on \`stake()\`.

## Changes

- Raise \`SOL_MIN_AMOUNT\` / \`MIN_AMOUNT\` to 1 SOL (1,000,000,000 lamports) in both packages
- Fix \`MIN_AMOUNT\` type to \`bigint\` literal (\`1000000000n\`) in \`solana_v2\` — was causing TypeError crash on every \`createAccount()\` and \`delegate()\` call
- Introduce \`MIN_SPLIT_REMAINDER\` / \`SOL_MIN_SPLIT_REMAINDER\` (0.01 SOL) as a separate dust threshold for the unstake split logic, decoupled from the user-facing minimum; prevents silent over-unstake where remainders of 0.01–0.99 SOL incorrectly triggered full account deactivation
- Add \`lamports < MIN_AMOUNT\` guard to \`stake()\` in both packages, closing the bypass of the 1-SOL minimum through the primary staking entrypoint

## Commits

9095b6c 🐛 fix(solana): fix bigint type mismatch, over-unstake, and missing stake() guard
52c1d44 ⚡️ feat(solana): raise min stake threshold from 0.01 to 1 SOL