### PR TITLE
🐛 fix(polygon): raise DELEGATE_BASE_GAS to 300_000

### DIFF
--- a/polygon/package.json
+++ b/polygon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everstake/wallet-sdk-polygon",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Polygon - Everstake Wallet SDK",
   "publishConfig": {
     "access": "public"

--- a/polygon/src/constants/index.ts
+++ b/polygon/src/constants/index.ts
@@ -18,7 +18,7 @@ export const ADDRESS_CONTRACT_BUY =
 
 export const MIN_AMOUNT = new BigNumber('1000000000000000000'); // 1 MATIC
 
-export const DELEGATE_BASE_GAS = 220000n;
+export const DELEGATE_BASE_GAS = 300000n;
 export const UNDELEGATE_BASE_GAS = 300000n;
 export const CLAIM_UNDELEGATE_BASE_GAS = 200000n;
 export const CLAIM_REWARDS_BASE_GAS = 180000n;


### PR DESCRIPTION
POL buyVoucherPOL transactions were consuming up to 212_552 gas (96.6% of the 220_000 limit), causing production stake failures. Raises the constant to 300_000 (~41% headroom) to prevent gas-limit rejections without introducing dynamic estimation.

Fixes DEV-3223